### PR TITLE
chore: add docs workflow

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,35 @@
+name: Generate Docs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install google-generativeai
+      - name: Generate documentation
+        run: python generate_docs.py
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add README.md $(find Problemas -name README.md -print)
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update docs"
+            git push
+          fi

--- a/Problemas/4A - Watermelon/README.md
+++ b/Problemas/4A - Watermelon/README.md
@@ -1,0 +1,9 @@
+# 4A - Watermelon
+
+This problem asks whether a watermelon of weight \(w\) kilograms can be split into two parts with even positive weight.
+
+**Logic:** a split is possible only when \(w\) is even and greater than 2.
+
+## Files
+- `4A_Watermelon.cpp` – C++ implementation.
+- `4A_Watermelon.py` – Python implementation.


### PR DESCRIPTION
## Summary
- add workflow to generate documentation using Gemini API and commit results
- document Watermelon problem

## Testing
- `pip install google-generativeai`
- `GEMINI_API_KEY=dummy python generate_docs.py` *(fails: SSL_ERROR_SSL: CERTIFICATE_VERIFY_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6896b556f8408327a0f9c36f2d737177

---
## EntelligenceAI PR Summary 
 This PR automates documentation updates and improves problem clarity.
- Added a GitHub Actions workflow for generating and committing documentation (generate-docs.yml)
- Introduced a README for '4A - Watermelon' with problem details and solution file listings 

